### PR TITLE
.envに追加したメールテンプレートIDを指定して、画面から利用できるようにする

### DIFF
--- a/app/config/eccube/packages/eccube.yaml
+++ b/app/config/eccube/packages/eccube.yaml
@@ -107,6 +107,7 @@ parameters:
     eccube_forgot_mail_template_id: 6 #パスワードリセット
     eccube_reset_complete_mail_template_id: 7 #パスワードリマインダー
     eccube_shipping_notify_mail_template_id: 8 #出荷通知メール
+    eccube_order_mail_templates_ids: '%env(json:ECCUBE_ORDER_MAIL_TEMPLATES_IDS)%'
     # メールアドレスをRFC準拠でチェックするか true: チェックする、false: チェックしない
     eccube_rfc_email_check: false
     eccube_package_api_url: '%env(ECCUBE_PACKAGE_API_URL)%'

--- a/src/Eccube/Form/Type/Admin/OrderMailType.php
+++ b/src/Eccube/Form/Type/Admin/OrderMailType.php
@@ -51,9 +51,9 @@ class OrderMailType extends AbstractType
                 'required' => false,
                 'mapped' => false,
                 'query_builder' => function (EntityRepository $er) {
-                    return $er->createQueryBuilder('mt')
-                        ->andWhere('mt.id = :id')
-                        ->setParameter('id', $this->eccubeConfig['eccube_order_mail_template_id'])
+                    $qb = $er->createQueryBuilder('mt');
+                    return $qb->andWhere($qb->expr()->in('mt.id', ':ids'))
+                        ->setParameter('ids', $this->eccubeConfig['eccube_order_mail_templates_ids'])
                         ->orderBy('mt.id', 'ASC');
                 },
             ])


### PR DESCRIPTION
.envの内容
`ECCUBE_ORDER_MAIL_TEMPLATES_IDS=[1,9]`

メールテンプレート作成先(Sample)
`app/template/default/Mail/test.twig`

マイグレーション
```
INSERT INTO `dtb_mail_template` (`creator_id`, `name`, `file_name`, `mail_subject`, `create_date`, `update_date`, `discriminator_type`)
VALUES
(NULL, 'テストメール', 'Mail/test.twig', 'テスト送信', 'NOW()', 'NOW()', 'mailtemplate');
```