### PR TITLE
請求書設定の登録番号の必須をはずす。

### DIFF
--- a/app/Customize/Form/Type/Admin/InvoiceMasterType.php
+++ b/app/Customize/Form/Type/Admin/InvoiceMasterType.php
@@ -175,9 +175,8 @@ class InvoiceMasterType extends AbstractType
                 ],
             ])
             ->add('registration_number', TextType::class, [
-                'required' => true,
+                'required' => false,
                 'constraints' => [
-                    new Assert\NotBlank(),
                     new Assert\Length([
                         'max' => $this->eccubeConfig['eccube_stext_len'],
                     ]),

--- a/app/template/admin/Setting/Invoice/customize_invoice_master.twig
+++ b/app/template/admin/Setting/Invoice/customize_invoice_master.twig
@@ -61,7 +61,6 @@ file that was distributed with this source code.
                                     <div class="d-inline-block" data-tooltip="true" data-placement="top" title="{{ 'customize.tooltip.invoice.registration_number'|trans }}">
                                         <span>{{ 'customize.admin.setting.invice.invoice.registration_number'|trans }}</span>
                                         <i class="fa fa-question-circle fa-lg ml-1"></i>
-                                        <span class="badge badge-primary ml-1">{{ 'admin.common.required'|trans }}</span>
                                     </div>
                                 </div>
                                 <div class="col mb-2">


### PR DESCRIPTION
テンプレートの修正も必要ですが、先にマージしても問題はありません。

テンプレートの修正がまだの場合は、登録番号が未入力の場合、Docurainの変数が表示されます。