### PR TITLE
[EC-CUBE] Fix: ファイル名に注文番号を含める

### DIFF
--- a/app/Customize/Service/OrderCustomPdfService.php
+++ b/app/Customize/Service/OrderCustomPdfService.php
@@ -94,6 +94,9 @@ class OrderCustomPdfService extends TcpdfFpdi
     /** 最後に処理した注文番号 @var string */
     private $lastOrderId = null;
 
+    /** 最後に処理した出荷番号 @var string */
+    private $currentOrderId = null;
+
     // --------------------------------------
     // Font情報のバックアップデータ
     /** @var string フォント名 */
@@ -211,7 +214,7 @@ class OrderCustomPdfService extends TcpdfFpdi
         }
 
         foreach ($ids as $id) {
-            $this->lastOrderId = $id;
+            $this->lastOrderId = $id; // orderと言いつつ、これはShippingのId
 
             // 出荷番号から出荷情報を取得する
             /** @var Shipping $Shipping */
@@ -223,6 +226,7 @@ class OrderCustomPdfService extends TcpdfFpdi
 
             // テンプレートファイルを読み込む
             $Order = $Shipping->getOrder();
+            $this->currentOrderId = $Order->getId();
 
             if (null !== $Order->getOriginalId()) {
                 $this->price_visible = false;
@@ -302,7 +306,8 @@ class OrderCustomPdfService extends TcpdfFpdi
         }
         $this->downloadFileName = self::DEFAULT_PDF_FILE_NAME;
         if ($this->PageNo() == 1) {
-            $this->downloadFileName = 'nouhinsyo-No'.$this->lastOrderId.'.pdf';
+            // example: nouhinsyo-order-No555-ship-No558.pdf
+            $this->downloadFileName = 'nouhinsyo-order-No'.$this->currentOrderId.'-ship-No'.$this->lastOrderId.'.pdf';
         }
 
         return $this->downloadFileName;

--- a/app/Customize/Service/OrderCustomPdfService.php
+++ b/app/Customize/Service/OrderCustomPdfService.php
@@ -92,10 +92,10 @@ class OrderCustomPdfService extends TcpdfFpdi
     private $widthCell = [];
 
     /** 最後に処理した注文番号 @var string */
-    private $lastOrderId = null;
+    private $lastShippingId = null
 
     /** 最後に処理した出荷番号 @var string */
-    private $currentOrderId = null;
+    private $lastOrderId = null;
 
     // --------------------------------------
     // Font情報のバックアップデータ
@@ -214,7 +214,7 @@ class OrderCustomPdfService extends TcpdfFpdi
         }
 
         foreach ($ids as $id) {
-            $this->lastOrderId = $id; // orderと言いつつ、これはShippingのId
+            $this->lastShippingId = $id;
 
             // 出荷番号から出荷情報を取得する
             /** @var Shipping $Shipping */
@@ -226,7 +226,7 @@ class OrderCustomPdfService extends TcpdfFpdi
 
             // テンプレートファイルを読み込む
             $Order = $Shipping->getOrder();
-            $this->currentOrderId = $Order->getId();
+            $this->lastOrderId = $Order->getId();
 
             if (null !== $Order->getOriginalId()) {
                 $this->price_visible = false;
@@ -307,7 +307,7 @@ class OrderCustomPdfService extends TcpdfFpdi
         $this->downloadFileName = self::DEFAULT_PDF_FILE_NAME;
         if ($this->PageNo() == 1) {
             // example: nouhinsyo-order-No555-ship-No558.pdf
-            $this->downloadFileName = 'nouhinsyo-order-No'.$this->currentOrderId.'-ship-No'.$this->lastOrderId.'.pdf';
+            $this->downloadFileName = 'nouhinsyo-order-No'.$this->lastOrderId.'-ship-No'.$this->lastShippingId.'.pdf';
         }
 
         return $this->downloadFileName;


### PR DESCRIPTION
ファイル名に出荷番号が出力されているが、注文番号と混同してしまうような形になっている。
そのため、注文番号・出荷番号の両方をファイル名に含めるように修正した。

例: nouhinsyo-order-No555-ship-No558.pdf
