### PR TITLE
商品リストの価格に税込のテキストを追加

### DIFF
--- a/app/template/default/Product/list.twig
+++ b/app/template/default/Product/list.twig
@@ -224,6 +224,9 @@ file that was distributed with this source code.
                                         {% else %}
                                             {{ Product.getPrice02IncTaxMin|price }}
                                         {% endif %}
+                                        {% if Product.getPrice02IncTaxMax > 0 %}
+                                            <span style="font-size: 0.77em;">{{ 'common.tax_include'|trans }}</span>
+                                        {% endif %}
                                     {% endif %}
                                 </p>
                             </a>


### PR DESCRIPTION
ミックスパックでも価格を設定でき、価格が表示される場合があるので、価格が0円でなければ税込のテキストを表示するようにしています。

ミックスパックも通常商品も、価格が０円の場合は価格が表示されないです。