### PR TITLE
ゆうパックで徳島の配送エリアが中国になっているのを四国に修正

### DIFF
--- a/initialize_data.sql
+++ b/initialize_data.sql
@@ -978,7 +978,7 @@ VALUES
 	(35, 41, 5, 'deliveryprefarea'),
 	(36, 10, 1, 'deliveryprefarea'),
 	(36, 23, 2, 'deliveryprefarea'),
-	(36, 33, 3, 'deliveryprefarea'),
+	(36, 34, 3, 'deliveryprefarea'),
 	(36, 37, 6, 'deliveryprefarea'),
 	(36, 40, 4, 'deliveryprefarea'),
 	(36, 41, 5, 'deliveryprefarea'),


### PR DESCRIPTION
徳島はpref_id=36
ゆうパックはdelivery_id=3

delivery_id=3のplg_delivery_fee_extension_dtb_delivery_areaは以下
```
        (26, 3, '北海道', 1, 'deliveryarea'),
        (27, 3, '東北', 2, 'deliveryarea'),
        (28, 3, '関東', 3, 'deliveryarea'),
        (29, 3, '信越', 4, 'deliveryarea'),
        (30, 3, '北陸', 5, 'deliveryarea'),
        (31, 3, '東海', 6, 'deliveryarea'),
        (32, 3, '近畿', 7, 'deliveryarea'),
        (33, 3, '中国', 8, 'deliveryarea'),
        (34, 3, '四国', 9, 'deliveryarea'),
        (35, 3, '九州', 10, 'deliveryarea'),
        (36, 3, '沖縄', 11, 'deliveryarea'),
```
delivery_id=3の33は `中国`。34の `四国` に変更
